### PR TITLE
use strings to avoid hitting the max int limit

### DIFF
--- a/Tests/v11/Tests/v11Test.php
+++ b/Tests/v11/Tests/v11Test.php
@@ -38,7 +38,6 @@ class v11Test extends \PHPUnit_Framework_TestCase
         $this->assertSame('123456000000001291146290519', $v11->getTransactionRecords()[0]->getReferenceNumber());
         $this->assertSame('12345600000000129114629051', $v11->getTransactionRecords()[0]->getReferenceNumberWithoutCheckDigit());
         $this->assertSame('00000000129114629051', $v11->getTransactionRecords()[0]->getCustomReferenceNumber());
-        $this->assertSame(129114629051, $v11->getTransactionRecords()[0]->getCustomReferenceNumber(true));
         $this->assertSame(75, $v11->getTransactionRecords()[0]->getAmount());
         $this->assertSame('0000000000', $v11->getTransactionRecords()[0]->getInternalBankReference());
         $this->assertSame('2014-10-24', $v11->getTransactionRecords()[0]->getDatePaid()->format('Y-m-d'));

--- a/example/example.php
+++ b/example/example.php
@@ -31,7 +31,7 @@ foreach($v11->getTransactionRecords() as $record){
             'Payment type' => $record->getTransactionCode()->getPaymentType(),
             'Amount' => $record->getSignedAmount(),
             'Full Reference number' => $record->getReferenceNumber(),
-            'Customer numeric reference number' => $record->getCustomReferenceNumber(true),
+            'Customer numeric reference number' => $record->getCustomReferenceNumber(),
             'Fee' => $record->getFee(),
         )
     );

--- a/lib/v11/Record/TransactionRecord.php
+++ b/lib/v11/Record/TransactionRecord.php
@@ -79,16 +79,9 @@ class TransactionRecord
         return substr($this->referenceNumber, 0, -1);
     }
 
-    public function getCustomReferenceNumber($numeric = false)
+    public function getCustomReferenceNumber()
     {
-        $customReferenceNumber = substr($this->getReferenceNumberWithoutCheckDigit(), strlen($this->getParticipantIdentifier()));
-
-        if ($numeric) {
-
-            return $customReferenceNumber * 1;
-        }
-
-        return $customReferenceNumber;
+        return substr($this->getReferenceNumberWithoutCheckDigit(), strlen($this->getParticipantIdentifier()));
     }
 
     public function setAmount($amount)


### PR DESCRIPTION
As already mentioned here https://github.com/Ticketpark/v11/issues/1
PHP can't handle numbers large enough to hold the customer reference unless we'd switch to some big int stuff, but I don't really see a need for that. If someone wants to get the factorial of the customer reference number they can cast the string.
